### PR TITLE
Always enable ANSI colors.

### DIFF
--- a/lib/toolbelt.js
+++ b/lib/toolbelt.js
@@ -7,6 +7,9 @@ var GitHub = require('./github').GitHub
 var ContentService = require('./content-service').ContentService
 var Presenter = require('./presenter').Presenter
 
+// Force ANSI colors in build output, even if we're running in a Docker container without a TTY.
+colors.enabled = true
+
 /*
  * Interactions with the job or build phase contexts.
  */


### PR DESCRIPTION
It turns out that `colors` automatically disables itself when run in a process without a TTY (such as within a Docker container that's run without `-t`). We're writing output to the Strider build anyway, so force it to be enabled.
